### PR TITLE
Add podspec File to use this Library with Cocoapods (branch: swift)

### DIFF
--- a/KeychainWrapper.podspec
+++ b/KeychainWrapper.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name = 'KeychainWrapper'
+  s.version = '1.0.3'
+  s.license = 'MIT'
+  s.summary = 'A simple static wrapper for the iOS Keychain to allow you to use it in a similar fashion to user defaults. Written in Swift.'
+  s.homepage = 'https://github.com/jrendel/KeychainWrapper'
+  s.authors = { 'Jason Rendel' => 'unkown@jasonrendel.com' }
+  s.source = { :git => 'https://github.com/jrendel/KeychainWrapper.git', :tag => '1.0.3' }
+
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
+
+  s.source_files = 'KeychainWrapper/*.swift'
+end


### PR DESCRIPTION
Hi,

i added a podspec File to use your Library with Cocoapods (only if you use the swift-branch of Cocoapods like described here http://swiftwala.com/cocoapods-is-ready-for-swift/)
But its not workin, i can install your Library with "bundle exec pod install" if defined in my Podfile, but i cant use it because a framework class/module called "KeychainWrapper" allready exists.