### PR TITLE
Swift2.0 Conversion

### DIFF
--- a/SwiftKeychainWrapper.xcodeproj/project.pbxproj
+++ b/SwiftKeychainWrapper.xcodeproj/project.pbxproj
@@ -169,6 +169,8 @@
 		961101BC19D2581700E6A6E3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Jason Rendel";
 				TargetAttributes = {

--- a/SwiftKeychainWrapper/KeychainWrapper.swift
+++ b/SwiftKeychainWrapper/KeychainWrapper.swift
@@ -81,8 +81,8 @@ public class KeychainWrapper {
     
     /// Checks if keychain data exists for a specified key.
     ///
-    /// :param: keyName The key to check for.
-    /// :returns: True if a value exists for the key. False otherwise.
+    /// - parameter keyName: The key to check for.
+    /// - returns: True if a value exists for the key. False otherwise.
     public class func hasValueForKey(keyName: String) -> Bool {
         let keychainData: NSData? = self.dataForKey(keyName)
         if keychainData != nil {
@@ -94,8 +94,8 @@ public class KeychainWrapper {
 
     /// Returns a string value for a specified key.
     ///
-    /// :param: keyName The key to lookup data for.
-    /// :returns: The String associated with the key if it exists. If no data exists, or the data found cannot be encoded as a string, returns nil.
+    /// - parameter keyName: The key to lookup data for.
+    /// - returns: The String associated with the key if it exists. If no data exists, or the data found cannot be encoded as a string, returns nil.
     public class func stringForKey(keyName: String) -> String? {
         let keychainData: NSData? = self.dataForKey(keyName)
         var stringValue: String?
@@ -109,8 +109,8 @@ public class KeychainWrapper {
     
     /// Returns an object that conforms to NSCoding for a specified key.
     ///
-    /// :param: keyName The key to lookup data for.
-    /// :returns: The decoded object associated with the key if it exists. If no data exists, or the data found cannot be decoded, returns nil.
+    /// - parameter keyName: The key to lookup data for.
+    /// - returns: The decoded object associated with the key if it exists. If no data exists, or the data found cannot be decoded, returns nil.
     public class func objectForKey(keyName: String) -> NSCoding? {
         let dataValue: NSData? = self.dataForKey(keyName)
 
@@ -126,8 +126,8 @@ public class KeychainWrapper {
     
     /// Returns a NSData object for a specified key.
     ///
-    /// :param: keyName The key to lookup data for.
-    /// :returns: The NSData object associated with the key if it exists. If no data exists, returns nil.
+    /// - parameter keyName: The key to lookup data for.
+    /// - returns: The NSData object associated with the key if it exists. If no data exists, returns nil.
     public class func dataForKey(keyName: String) -> NSData? {
         var keychainQueryDictionary = self.setupKeychainQueryDictionaryForKey(keyName)
         var result: AnyObject?
@@ -148,9 +148,9 @@ public class KeychainWrapper {
 
     /// Save a String value to the keychain associated with a specified key. If a String value already exists for the given keyname, the string will be overwritten with the new value.
     ///
-    /// :param: value The String value to save.
-    /// :param: forKey The key to save the String under.
-    /// :returns: True if the save was successful, false otherwise.
+    /// - parameter value: The String value to save.
+    /// - parameter forKey: The key to save the String under.
+    /// - returns: True if the save was successful, false otherwise.
     public class func setString(value: String, forKey keyName: String) -> Bool {
         if let data = value.dataUsingEncoding(NSUTF8StringEncoding) {
             return self.setData(data, forKey: keyName)
@@ -161,9 +161,9 @@ public class KeychainWrapper {
 
     /// Save an NSCoding compliant object to the keychain associated with a specified key. If an object already exists for the given keyname, the object will be overwritten with the new value.
     ///
-    /// :param: value The NSCoding compliant object to save.
-    /// :param: forKey The key to save the object under.
-    /// :returns: True if the save was successful, false otherwise.
+    /// - parameter value: The NSCoding compliant object to save.
+    /// - parameter forKey: The key to save the object under.
+    /// - returns: True if the save was successful, false otherwise.
     public class func setObject(value: NSCoding, forKey keyName: String) -> Bool {
         let data = NSKeyedArchiver.archivedDataWithRootObject(value)
 
@@ -172,9 +172,9 @@ public class KeychainWrapper {
 
     /// Save a NSData object to the keychain associated with a specified key. If data already exists for the given keyname, the data will be overwritten with the new value.
     ///
-    /// :param: value The NSData object to save.
-    /// :param: forKey The key to save the object under.
-    /// :returns: True if the save was successful, false otherwise.
+    /// - parameter value: The NSData object to save.
+    /// - parameter forKey: The key to save the object under.
+    /// - returns: True if the save was successful, false otherwise.
     public class func setData(value: NSData, forKey keyName: String) -> Bool {
         var keychainQueryDictionary: [String:AnyObject] = self.setupKeychainQueryDictionaryForKey(keyName)
 
@@ -196,8 +196,8 @@ public class KeychainWrapper {
 
     /// Remove an object associated with a specified key.
     ///
-    /// :param: keyName The key value to remove data for.
-    /// :returns: True if successful, false otherwise.
+    /// - parameter keyName: The key value to remove data for.
+    /// - returns: True if successful, false otherwise.
     public class func removeObjectForKey(keyName: String) -> Bool {
         let keychainQueryDictionary: [String:AnyObject] = self.setupKeychainQueryDictionaryForKey(keyName)
 
@@ -230,8 +230,8 @@ public class KeychainWrapper {
 
     /// Setup the keychain query dictionary used to access the keychain on iOS for a specified key name. Takes into account the Service Name and Access Group if one is set.
     ///
-    /// :param: keyName The key this query is for
-    /// :returns: A dictionary with all the needed properties setup to access the keychain on iOS
+    /// - parameter keyName: The key this query is for
+    /// - returns: A dictionary with all the needed properties setup to access the keychain on iOS
     private class func setupKeychainQueryDictionaryForKey(keyName: String) -> [String:AnyObject] {
         // Setup dictionary to access keychain and specify we are using a generic password (rather than a certificate, internet password, etc)
         var keychainQueryDictionary: [String:AnyObject] = [SecClass:kSecClassGenericPassword]

--- a/SwiftKeychainWrapperTests/testObject.swift
+++ b/SwiftKeychainWrapperTests/testObject.swift
@@ -33,7 +33,7 @@ class testObject: NSObject, NSCoding {
     
     override init() { }
     
-    required init(coder decoder: NSCoder) {
+    required init?(coder decoder: NSCoder) {
         if let name = decoder.decodeObjectForKey("objectName") as? String {
             self.objectName = name
         }


### PR DESCRIPTION
Ran the Swift 2.0 Converter with Xcode 7 on the SwiftKeychainWrapper project.

There was one code change in the test testObject's `required init(coder: NSCoder)` became option.
The other change were recording that a conversion was run and updating the syntax of the documentation.
