### PR TITLE
Add a func to search persistent data reference

### DIFF
--- a/SwiftKeychainWrapper.xcodeproj/project.pbxproj
+++ b/SwiftKeychainWrapper.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Jason Rendel";
 				TargetAttributes = {
 					9694C2AF1A66097F005B3030 = {
@@ -250,6 +250,7 @@
 		961101C019D2581700E6A6E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -306,6 +307,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jasonrendel.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -354,6 +356,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jasonrendel.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -406,6 +409,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jasonrendel.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 			};
@@ -447,6 +451,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jasonrendel.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/SwiftKeychainWrapper.xcodeproj/xcshareddata/xcschemes/SwiftKeychainWrapper.xcscheme
+++ b/SwiftKeychainWrapper.xcodeproj/xcshareddata/xcschemes/SwiftKeychainWrapper.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:SwiftKeychainWrapper.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/SwiftKeychainWrapper/Info.plist
+++ b/SwiftKeychainWrapper/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.jasonrendel.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwiftKeychainWrapper/KeychainWrapper.swift
+++ b/SwiftKeychainWrapper/KeychainWrapper.swift
@@ -30,6 +30,7 @@ import Foundation
 
 private let SecMatchLimit: String! = kSecMatchLimit as String
 private let SecReturnData: String! = kSecReturnData as String
+private let SecReturnPersistentRef: String! = kSecReturnPersistentRef as String
 private let SecValueData: String! = kSecValueData as String
 private let SecAttrAccessible: String! = kSecAttrAccessible as String
 private let SecClass: String! = kSecClass as String
@@ -145,6 +146,30 @@ public class KeychainWrapper {
 
         return status == noErr ? result as? NSData : nil
     }
+    
+    
+    /// Returns a persistent data reference object for a specified key.
+    ///
+    /// - parameter keyName: The key to lookup data for.
+    /// - returns: The persistent data reference object associated with the key if it exists. If no data exists, returns nil.
+    public class func dataRefForKey(keyName: String) -> NSData? {
+        var keychainQueryDictionary = self.setupKeychainQueryDictionaryForKey(keyName)
+        var result: AnyObject?
+        
+        // Limit search results to one
+        keychainQueryDictionary[SecMatchLimit] = kSecMatchLimitOne
+        
+        // Specify we want persistent NSData/CFData reference returned
+        keychainQueryDictionary[SecReturnPersistentRef] = kCFBooleanTrue
+        
+        // Search
+        let status = withUnsafeMutablePointer(&result) {
+            SecItemCopyMatching(keychainQueryDictionary, UnsafeMutablePointer($0))
+        }
+        
+        return status == noErr ? result as? NSData : nil
+    }
+    
 
     /// Save a String value to the keychain associated with a specified key. If a String value already exists for the given keyname, the string will be overwritten with the new value.
     ///

--- a/SwiftKeychainWrapper/KeychainWrapper.swift
+++ b/SwiftKeychainWrapper/KeychainWrapper.swift
@@ -28,15 +28,15 @@
 import Foundation
 
 
-let SecMatchLimit: String! = kSecMatchLimit as String
-let SecReturnData: String! = kSecReturnData as String
-let SecValueData: String! = kSecValueData as String
-let SecAttrAccessible: String! = kSecAttrAccessible as String
-let SecClass: String! = kSecClass as String
-let SecAttrService: String! = kSecAttrService as String
-let SecAttrGeneric: String! = kSecAttrGeneric as String
-let SecAttrAccount: String! = kSecAttrAccount as String
-let SecAttrAccessGroup: String! = kSecAttrAccessGroup as String
+private let SecMatchLimit: String! = kSecMatchLimit as String
+private let SecReturnData: String! = kSecReturnData as String
+private let SecValueData: String! = kSecValueData as String
+private let SecAttrAccessible: String! = kSecAttrAccessible as String
+private let SecClass: String! = kSecClass as String
+private let SecAttrService: String! = kSecAttrService as String
+private let SecAttrGeneric: String! = kSecAttrGeneric as String
+private let SecAttrAccount: String! = kSecAttrAccount as String
+private let SecAttrAccessGroup: String! = kSecAttrAccessGroup as String
 
 /// KeychainWrapper is a class to help make Keychain access in Swift more straightforward. It is designed to make accessing the Keychain services more like using NSUserDefaults, which is much more familiar to people.
 public class KeychainWrapper {

--- a/SwiftKeychainWrapperTests/Info.plist
+++ b/SwiftKeychainWrapperTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.jasonrendel.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwiftKeychainWrapperTests/KeychainWrapperTests.swift
+++ b/SwiftKeychainWrapperTests/KeychainWrapperTests.swift
@@ -225,28 +225,38 @@ class KeychainWrapperTests: XCTestCase {
     }
     
     func testNSDataRetrieval() {
-        let testData = testString.dataUsingEncoding(NSUTF8StringEncoding)
-        
-        if let data = testData {
-            KeychainWrapper.setData(data, forKey: testKey)
-            
-            if let retrievedData = KeychainWrapper.dataForKey(testKey) {
-                if let retrievedString = NSString(data: retrievedData, encoding: NSUTF8StringEncoding) {
-                    XCTAssertEqual(retrievedString, testString, "String retrieved from data for key should equal string saved as data for key")
-                } else {
-                    XCTFail("Output Data for key does not match input. ")
-                }
-            } else {
-                XCTFail("Data for Key not found")
-            }
-        } else {
+        guard let testData = testString.dataUsingEncoding(NSUTF8StringEncoding) else {
             XCTFail("Failed to create NSData")
+            return
+        }
+        
+        KeychainWrapper.setData(testData, forKey: testKey)
+        
+        guard let retrievedData = KeychainWrapper.dataForKey(testKey) else {
+            XCTFail("Data for Key not found")
+            return
+        }
+        
+        if KeychainWrapper.dataRefForKey(testKey) == nil {
+            XCTFail("Data references for Key not found")
+        }
+        
+        if let retrievedString = NSString(data: retrievedData, encoding: NSUTF8StringEncoding) {
+            XCTAssertEqual(retrievedString, testString, "String retrieved from data for key should equal string saved as data for key")
+        } else {
+            XCTFail("Output Data for key does not match input. ")
         }
     }
     
     func testNSDataRetrievalWhenValueDoesNotExist() {
         if let _ = KeychainWrapper.dataForKey(testKey) {
             XCTFail("Data for Key should not exist")
+        } else {
+            XCTAssert(true, "Pass")
+        }
+        
+        if let _ = KeychainWrapper.dataRefForKey(testKey) {
+            XCTFail("Data ref for Key should not exist")
         } else {
             XCTAssert(true, "Pass")
         }

--- a/SwiftKeychainWrapperTests/KeychainWrapperTests.swift
+++ b/SwiftKeychainWrapperTests/KeychainWrapperTests.swift
@@ -126,7 +126,7 @@ class KeychainWrapperTests: XCTestCase {
     }
     
     func testStringRetrievalWhenValueDoesNotExist() {
-        if let retrievedString = KeychainWrapper.stringForKey(testKey) {
+        if let _ = KeychainWrapper.stringForKey(testKey) {
             XCTFail("String for Key should not exist")
         } else {
             XCTAssert(true, "Pass")
@@ -189,8 +189,8 @@ class KeychainWrapperTests: XCTestCase {
     }
     
     func testNSCodingObjectRetrieval() {
-        var testInt: Int = 9
-        var myTestObject = testObject()
+        let testInt: Int = 9
+        let myTestObject = testObject()
         myTestObject.objectName = testString
         myTestObject.objectRating = testInt
         
@@ -205,7 +205,7 @@ class KeychainWrapperTests: XCTestCase {
     }
     
     func testNSCodingObjectRetrievalWhenValueDoesNotExist() {
-        if let retrievedObject = KeychainWrapper.objectForKey(testKey) as? testObject{
+        if let _ = KeychainWrapper.objectForKey(testKey) as? testObject{
             XCTFail("Object for Key should not exist")
         } else {
             XCTAssert(true, "Pass")
@@ -245,7 +245,7 @@ class KeychainWrapperTests: XCTestCase {
     }
     
     func testNSDataRetrievalWhenValueDoesNotExist() {
-        if let retrievedData = KeychainWrapper.dataForKey(testKey) {
+        if let _ = KeychainWrapper.dataForKey(testKey) {
             XCTFail("Data for Key should not exist")
         } else {
             XCTAssert(true, "Pass")


### PR DESCRIPTION
In order to load certificates or passwords for some system frameworks like NetworkExtension, we need to get the persistent NSData reference of them instead of the original NSData. I've added the function in my fork and tested in [another side project](https://github.com/lexrus/vpnon) for about 10 months. Since the Swift 2.0 branch is ready, I guess it's time to send a pull request.

Thanks.