### PR TITLE
Set APPLICATION_ENTENSION_API_ONLY to YES.

### DIFF
--- a/SwiftKeychainWrapper.xcodeproj/project.pbxproj
+++ b/SwiftKeychainWrapper.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -321,6 +322,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
`Linking against dylib not safe for use in application extensions`
We can't use this lib in extension targets(eg. Today Widget / WatchKit Extension ...) without this setting.