### PR TITLE
Set APPLICATION_EXTENSION_API_ONLY to YES for use in extensions

### DIFF
--- a/SwiftKeychainWrapper.xcodeproj/project.pbxproj
+++ b/SwiftKeychainWrapper.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		961101C019D2581700E6A6E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ENABLE_TESTABILITY = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -259,6 +260,7 @@
 		961101C119D2581700E6A6E3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
When linking against a Carthage built version of SwiftKeychainWrapper I kept getting an error saying that the dylib wasn't safe for use in extensions. This patch enables the `Require Only App-Extension-Safe API` flag for the base xcodeproj which makes the warning go away.