### PR TITLE
Add KeychainItemOptions struct and supporting enums. Support options in KeychainWrapper public API.

### DIFF
--- a/SwiftKeychainWrapper.xcodeproj/project.pbxproj
+++ b/SwiftKeychainWrapper.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AC6BBDA1CCD272C00DE429B /* KeychainOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC6BBD91CCD272C00DE429B /* KeychainOptions.swift */; };
 		474429821CAAA6FD0042B03E /* KeychainWrapperSubscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474429811CAAA6FD0042B03E /* KeychainWrapperSubscriptTests.swift */; };
 		477728B91CAF29E500905FE4 /* KeychainWrapperPrimitiveValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477728B81CAF29E500905FE4 /* KeychainWrapperPrimitiveValueTests.swift */; };
 		477728BB1CAF306300905FE4 /* KeychainWrapper+Experimental.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477728BA1CAF306300905FE4 /* KeychainWrapper+Experimental.swift */; };
@@ -30,6 +31,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1AC6BBD91CCD272C00DE429B /* KeychainOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainOptions.swift; sourceTree = "<group>"; };
 		474429811CAAA6FD0042B03E /* KeychainWrapperSubscriptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainWrapperSubscriptTests.swift; sourceTree = "<group>"; };
 		477728B81CAF29E500905FE4 /* KeychainWrapperPrimitiveValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainWrapperPrimitiveValueTests.swift; sourceTree = "<group>"; };
 		477728BA1CAF306300905FE4 /* KeychainWrapper+Experimental.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "KeychainWrapper+Experimental.swift"; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 				9694C2B41A66097F005B3030 /* SwiftKeychainWrapper.h */,
 				9694C2CC1A660F90005B3030 /* KeychainWrapper.swift */,
 				477728BA1CAF306300905FE4 /* KeychainWrapper+Experimental.swift */,
+				1AC6BBD91CCD272C00DE429B /* KeychainOptions.swift */,
 				9694C2B21A66097F005B3030 /* Supporting Files */,
 			);
 			path = SwiftKeychainWrapper;
@@ -236,6 +239,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9694C2CD1A660F90005B3030 /* KeychainWrapper.swift in Sources */,
+				1AC6BBDA1CCD272C00DE429B /* KeychainOptions.swift in Sources */,
 				477728BB1CAF306300905FE4 /* KeychainWrapper+Experimental.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftKeychainWrapper/KeychainOptions.swift
+++ b/SwiftKeychainWrapper/KeychainOptions.swift
@@ -1,0 +1,220 @@
+//
+//  KeychainOptions.swift
+//  SwiftKeychainWrapper
+//
+//  Created by James Blair on 4/24/16.
+//  Copyright © 2016 Jason Rendel. All rights reserved.
+//
+
+import Foundation
+
+public struct KeychainItemOptions {
+    let itemClass: KeychainItemClass
+    let itemAccessibility: KeychainItemAccessibility
+    
+    init(itemClass: KeychainItemClass = .GenericPassword,
+         itemAccessibility: KeychainItemAccessibility = .WhenUnlocked) {
+        self.itemClass = itemClass
+        self.itemAccessibility = itemAccessibility
+    }
+}
+
+protocol KeychainAttrRepresentable {
+    var keychainAttrValue: CFString { get }
+}
+
+// MARK: - KeychainItemClass
+
+/**
+ Item class code of a Keychain item.
+ */
+public enum KeychainItemClass {
+    /**
+     Generic password item.
+     
+     The following attribute types (Attribute Item Keys and Values) can be used with an item of this type:
+     - kSecAttrAccessible
+     - kSecAttrAccessGroup
+     - kSecAttrCreationDate
+     - kSecAttrModificationDate
+     - kSecAttrDescription
+     - kSecAttrComment
+     - kSecAttrCreator
+     - kSecAttrType
+     - kSecAttrLabel
+     - kSecAttrIsInvisible
+     - kSecAttrIsNegative
+     - kSecAttrAccount
+     - kSecAttrService
+     - kSecAttrGeneric
+    */
+    @available(iOS 2, *)
+    case GenericPassword
+    
+    /**
+     Internet password item.
+     
+     The following attribute types (Attribute Item Keys and Values) can be used with an item of this type:
+     - kSecAttrAccessible
+     - kSecAttrAccessGroup
+     - kSecAttrCreationDate
+     - kSecAttrModificationDate
+     - kSecAttrDescription
+     - kSecAttrComment
+     - kSecAttrCreator
+     - kSecAttrType
+     - kSecAttrLabel
+     - kSecAttrIsInvisible
+     - kSecAttrIsNegative
+     - kSecAttrAccount
+     - kSecAttrSecurityDomain
+     - kSecAttrServer
+     - kSecAttrProtocol
+     - kSecAttrAuthenticationType
+     - kSecAttrPort
+     - kSecAttrPath
+    */
+    @available(iOS 2, *)
+    case InternetPassword
+    
+    /**
+     Certificate item.
+     
+     The following attribute types (Attribute Item Keys and Values) can be used with an item of this type:
+     - kSecAttrAccessible
+     - kSecAttrAccessGroup
+     - kSecAttrCertificateType
+     - kSecAttrCertificateEncoding
+     - kSecAttrLabel
+     - kSecAttrSubject
+     - kSecAttrIssuer
+     - kSecAttrSerialNumber
+     - kSecAttrSubjectKeyID
+     - kSecAttrPublicKeyHash
+     */
+    @available(iOS 2, *)
+    case Certificate
+    
+    /**
+     Cryptographic key item.
+     
+     The following attribute types (Attribute Item Keys and Values) can be used with an item of this type:
+     - kSecAttrAccessible
+     - kSecAttrAccessGroup
+     - kSecAttrKeyClass
+     - kSecAttrLabel
+     - kSecAttrApplicationLabel
+     - kSecAttrIsPermanent
+     - kSecAttrApplicationTag
+     - kSecAttrKeyType
+     - kSecAttrKeySizeInBits
+     - kSecAttrEffectiveKeySize
+     - kSecAttrCanEncrypt
+     - kSecAttrCanDecrypt
+     - kSecAttrCanDerive
+     - kSecAttrCanSign
+     - kSecAttrCanVerify
+     - kSecAttrCanWrap
+     - kSecAttrCanUnwrap
+     */
+    @available(iOS 2, *)
+    case Key
+    
+    /**
+     An identity is a certificate together with its associated private key. Because an identity is the combination of a private key and a certificate, this class shares attributes of both kSecClassKey and kSecClassCertificate.
+     */
+    @available(iOS 2, *)
+    case Identity
+}
+
+private let keychainItemClassLookup: [KeychainItemClass:CFString] = [
+    .GenericPassword: kSecClassGenericPassword,
+    .InternetPassword: kSecClassInternetPassword,
+    .Certificate: kSecClassCertificate,
+    .Key: kSecClassKey,
+    .Identity: kSecClassIdentity
+]
+
+extension KeychainItemClass : KeychainAttrRepresentable {
+    internal var keychainAttrValue: CFString {
+        return keychainItemClassLookup[self]!
+    }
+}
+
+
+// MARK: - KeychainItemAccessibility
+public enum KeychainItemAccessibility {
+    /**
+     The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
+     
+     After the first unlock, the data remains accessible until the next restart. This is recommended for items that need to be accessed by background applications. Items with this attribute migrate to a new device when using encrypted backups.
+    */
+    @available(iOS 4, *)
+    case AfterFirstUnlock
+    
+    /**
+     The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
+     
+     After the first unlock, the data remains accessible until the next restart. This is recommended for items that need to be accessed by background applications. Items with this attribute do not migrate to a new device. Thus, after restoring from a backup of a different device, these items will not be present.
+     */
+    @available(iOS 4, *)
+    case AfterFirstUnlockThisDeviceOnly
+    
+    /**
+     The data in the keychain item can always be accessed regardless of whether the device is locked.
+     
+     This is not recommended for application use. Items with this attribute migrate to a new device when using encrypted backups.
+     */
+    @available(iOS 4, *)
+    case Always
+    
+    /**
+     The data in the keychain can only be accessed when the device is unlocked. Only available if a passcode is set on the device.
+     
+     This is recommended for items that only need to be accessible while the application is in the foreground. Items with this attribute never migrate to a new device. After a backup is restored to a new device, these items are missing. No items can be stored in this class on devices without a passcode. Disabling the device passcode causes all items in this class to be deleted.
+     */
+    @available(iOS 8, *)
+    case WhenPasscodeSetThisDeviceOnly
+    
+    /**
+     The data in the keychain item can always be accessed regardless of whether the device is locked.
+     
+     This is not recommended for application use. Items with this attribute do not migrate to a new device. Thus, after restoring from a backup of a different device, these items will not be present.
+     */
+    @available(iOS 4, *)
+    case AlwaysThisDeviceOnly
+    
+    /**
+     The data in the keychain item can be accessed only while the device is unlocked by the user.
+     
+     This is recommended for items that need to be accessible only while the application is in the foreground. Items with this attribute migrate to a new device when using encrypted backups.
+     
+     This is the default value for keychain items added without explicitly setting an accessibility constant.
+     */
+    @available(iOS 4, *)
+    case WhenUnlocked
+    
+    /**
+     The data in the keychain item can be accessed only while the device is unlocked by the user.
+     
+     This is recommended for items that need to be accessible only while the application is in the foreground. Items with this attribute do not migrate to a new device. Thus, after restoring from a backup of a different device, these items will not be present.
+     */
+    @available(iOS 4, *)
+    case WhenUnlockedThisDeviceOnly
+}
+
+private let keychainItemAccessibilityLookup: [KeychainItemAccessibility:CFString] = [
+    .AfterFirstUnlock: kSecAttrAccessibleAfterFirstUnlock,
+    .AfterFirstUnlockThisDeviceOnly: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+    .Always: kSecAttrAccessibleAlways,
+    .WhenPasscodeSetThisDeviceOnly: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+    .AlwaysThisDeviceOnly : kSecAttrAccessibleAlwaysThisDeviceOnly,
+    .WhenUnlocked: kSecAttrAccessibleWhenUnlocked,
+    .WhenUnlockedThisDeviceOnly: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+]
+
+extension KeychainItemAccessibility : KeychainAttrRepresentable {
+    internal var keychainAttrValue: CFString {
+        return keychainItemAccessibilityLookup[self]!
+    }
+}


### PR DESCRIPTION
This is a sample implementation of the method parameter options design I had in mind for SecClass and SecAttrAccessible. The options type could be could be extended further for other attributes. I also added method overloads in the KeychainWrapper class to support the options parameter. What are your thoughts on an implementation like this?