### PR TITLE
Enable macOS usage of Pod

### DIFF
--- a/SwiftKeychainWrapper.podspec
+++ b/SwiftKeychainWrapper.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.license = 'MIT'
   s.authors = { 'Jason Rendel' => 'jason@jasonrendel.com' }
   s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.10'
   s.source = { :git => 'https://github.com/jrendel/SwiftKeychainWrapper.git', :tag => s.version }
   s.source_files = 'SwiftKeychainWrapper/*.{h,swift}'
 end

--- a/SwiftKeychainWrapper/SwiftKeychainWrapper.h
+++ b/SwiftKeychainWrapper/SwiftKeychainWrapper.h
@@ -24,7 +24,7 @@
 //    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //    SOFTWARE.
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for SwiftKeychainWrapper.
 FOUNDATION_EXPORT double SwiftKeychainWrapperVersionNumber;


### PR DESCRIPTION
Small changes to allow for pod inclusion in macOS projects. Address issue #43. 

Ideally, there’d be a Mac target for both the framework and tests. I did hack one in locally to check things out, but it’s currently messy enough with regards to naming etc that I’m going to hold off on sending it up.