### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ KeychainWrapper.standard.set("Some String", forKey: "myKey", withAccessibility: 
 
 ##Installation
 
+* Activate "Keychain Sharing" Capability
+
 #### CocoaPods
 You can use [CocoaPods](http://cocoapods.org/) to install SwiftKeychainWrapper by adding it to your `Podfile`:
 


### PR DESCRIPTION
Add a line to mention in swift3 and Xcode 8 it is necessary to activate "Keychain Sharing" on Capabilities tab