### PR TITLE
Xcode 10.2 warning removal

### DIFF
--- a/SwiftKeychainWrapper/KeychainWrapper.swift
+++ b/SwiftKeychainWrapper/KeychainWrapper.swift
@@ -43,7 +43,7 @@ private let SecReturnAttributes: String = kSecReturnAttributes as String
 /// KeychainWrapper is a class to help make Keychain access in Swift more straightforward. It is designed to make accessing the Keychain services more like using NSUserDefaults, which is much more familiar to people.
 open class KeychainWrapper {
     
-    @available(*, deprecated, message: "KeychainWrapper.defaultKeychainWrapper is deprecated, use KeychainWrapper.standard instead")
+    @available(*, deprecated, message: "KeychainWrapper.defaultKeychainWrapper is deprecated since version 2.2.1, use KeychainWrapper.standard instead")
     public static let defaultKeychainWrapper = KeychainWrapper.standard
     
     /// Default keychain wrapper access
@@ -320,7 +320,7 @@ open class KeychainWrapper {
         }
     }
 
-    @available(*, deprecated, message: "remove is deprecated, use removeObject instead")
+    @available(*, deprecated, message: "remove is deprecated since version 2.2.1, use removeObject instead")
     @discardableResult open func remove(key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil) -> Bool {
         return removeObject(forKey: key, withAccessibility: accessibility)
     }

--- a/SwiftKeychainWrapper/KeychainWrapper.swift
+++ b/SwiftKeychainWrapper/KeychainWrapper.swift
@@ -43,7 +43,7 @@ private let SecReturnAttributes: String = kSecReturnAttributes as String
 /// KeychainWrapper is a class to help make Keychain access in Swift more straightforward. It is designed to make accessing the Keychain services more like using NSUserDefaults, which is much more familiar to people.
 open class KeychainWrapper {
     
-    @available(*, deprecated: 2.2.1, message: "KeychainWrapper.defaultKeychainWrapper is deprecated, use KeychainWrapper.standard instead")
+    @available(*, deprecated, message: "KeychainWrapper.defaultKeychainWrapper is deprecated, use KeychainWrapper.standard instead")
     public static let defaultKeychainWrapper = KeychainWrapper.standard
     
     /// Default keychain wrapper access
@@ -320,7 +320,7 @@ open class KeychainWrapper {
         }
     }
 
-    @available(*, deprecated: 2.2.1, message: "remove is deprecated, use removeObject instead")
+    @available(*, deprecated, message: "remove is deprecated, use removeObject instead")
     @discardableResult open func remove(key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil) -> Bool {
         return removeObject(forKey: key, withAccessibility: accessibility)
     }


### PR DESCRIPTION
Removed compilation warning related to incorrectly used @available attribute shown when compiling in Xcode 10.2