### PR TITLE
Travis CI Improvements and updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode11
 
 script:
-    - xcodebuild test -scheme SwiftKeychainWrapper -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone SE,OS=10.1"
+    - xcodebuild test -scheme SwiftKeychainWrapper -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone SE,OS=12.1"
+#    - xcodebuild test -scheme SwiftKeychainWrapper -sdk appletvsimulator -destination "platform=tvOS Simulator,name=Apple TV,OS=12.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11
+osx_image: xcode10.2
 
 script:
     - xcodebuild test -scheme SwiftKeychainWrapper -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone SE,OS=12.1"


### PR DESCRIPTION
Upgrade Xcode version to 10.2 and iOS version to 12.
Also prepare for tvOS support but is commented out right now because that depends on https://github.com/jrendel/SwiftKeychainWrapper/pull/129.