### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftKeychainWrapper",
+    products: [
+        .library(
+            name: "SwiftKeychainWrapper",
+            targets: ["SwiftKeychainWrapper"]),
+    ],
+    targets: [
+        .target(
+            name: "SwiftKeychainWrapper",
+            path: "SwiftKeychainWrapper")
+    ]
+)


### PR DESCRIPTION
I have added package.swift file to support SPM.
Note that I did not specify minimum platform version as it is iOS 8 by default.