### PR TITLE
Added SPM Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.swiftpm/
 
 # CocoaPods
 #

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.1
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftKeychainWrapper",
+    products: [
+        .library(name: "SwiftKeychainWrapper", targets: ["SwiftKeychainWrapper"])
+    ],
+    targets: [
+        .target(name: "SwiftKeychainWrapper", path: "SwiftKeychainWrapper"),
+        .testTarget(name: "SwiftKeychainWrapperTests", dependencies: ["SwiftKeychainWrapper"], path: "SwiftKeychainWrapperTests")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ Swift 2.3:
 github "jrendel/SwiftKeychainWrapper" == 2.1.1
 ```
 
+#### Swift Package Manager
+You can use [Swift Package Manager](https://swift.org/package-manager/) to install SwiftKeychainWrapper using Xcode:
+
+1. Open your project in Xcode
+
+2. Click "File" -> "Swift Packages" -> "Add Package Dependency..."
+
+3. Paste the following URL: https://github.com/jrendel/SwiftKeychainWrapper
+
+4. Click "Next" -> "Next" -> "Finish"
+
+
 #### Manually
 Download and drop ```KeychainWrapper.swift``` and ```KeychainItemAcessibility.swift``` into your project.
 


### PR DESCRIPTION
- Added Package.swift manifest
- Updated README.md with SPM instructions
- Updated .gitignore for swiftpm folder

A new release would need to be created for SPM to see the manifest. Or just change my instructions in the readme to have them select the develop branch when importing package.