### PR TITLE
Improve on `KeychainItemAccessibility`

### DIFF
--- a/SwiftKeychainWrapper/KeychainWrapper.swift
+++ b/SwiftKeychainWrapper/KeychainWrapper.swift
@@ -109,7 +109,7 @@ open class KeychainWrapper {
             return nil
         }
     
-        return KeychainItemAccessibility.accessibilityForAttributeValue(accessibilityAttrValue as CFString)
+        return KeychainItemAccessibility(rawValue: accessibilityAttrValue as CFString)
     }
 
     /// Get the keys of all keychain entries matching the current ServiceName and AccessGroup if one is set.
@@ -322,10 +322,10 @@ open class KeychainWrapper {
         keychainQueryDictionary[SecValueData] = value
         
         if let accessibility = accessibility {
-            keychainQueryDictionary[SecAttrAccessible] = accessibility.keychainAttrValue
+            keychainQueryDictionary[SecAttrAccessible] = accessibility.rawValue
         } else {
             // Assign default protection - Protect the keychain entry so it's only valid when the device is unlocked
-            keychainQueryDictionary[SecAttrAccessible] = KeychainItemAccessibility.whenUnlocked.keychainAttrValue
+            keychainQueryDictionary[SecAttrAccessible] = KeychainItemAccessibility.whenUnlocked.rawValue
         }
         
         let status: OSStatus = SecItemAdd(keychainQueryDictionary as CFDictionary, nil)
@@ -420,7 +420,7 @@ open class KeychainWrapper {
         
         // on update, only set accessibility if passed in
         if let accessibility = accessibility {
-            keychainQueryDictionary[SecAttrAccessible] = accessibility.keychainAttrValue
+            keychainQueryDictionary[SecAttrAccessible] = accessibility.rawValue
         }
         
         // Update
@@ -448,7 +448,7 @@ open class KeychainWrapper {
         
         // Only set accessibiilty if its passed in, we don't want to default it here in case the user didn't want it set
         if let accessibility = accessibility {
-            keychainQueryDictionary[SecAttrAccessible] = accessibility.keychainAttrValue
+            keychainQueryDictionary[SecAttrAccessible] = accessibility.rawValue
         }
         
         // Set the keychain access group if defined

--- a/SwiftKeychainWrapperTests/KeychainWrapperTests.swift
+++ b/SwiftKeychainWrapperTests/KeychainWrapperTests.swift
@@ -34,9 +34,7 @@ class KeychainWrapperTests: XCTestCase {
         let accessibilityOptions: [KeychainItemAccessibility] = [
             .afterFirstUnlock,
             .afterFirstUnlockThisDeviceOnly,
-            .always,
             .whenPasscodeSetThisDeviceOnly,
-            .alwaysThisDeviceOnly,
             .whenUnlocked,
             .whenUnlockedThisDeviceOnly
         ]
@@ -45,7 +43,7 @@ class KeychainWrapperTests: XCTestCase {
         
         for accessibilityOption in accessibilityOptions {
             KeychainWrapper.standard.set("Test123", forKey: key, withAccessibility: accessibilityOption)
-        
+            
             let accessibilityForKey = KeychainWrapper.standard.accessibilityOfKey(key)
             
             let accessibilityDescription = String(describing: accessibilityForKey)


### PR DESCRIPTION
### Version and platform specific logic in order to bypass deprecation warnings, fixing #156. 

- [x] Update `NSKeyedArchiver` and `NSKeyedUnarchiver` methods
- [x] Obfuscate `kSecAttrAccessibleAlways` and `kSecAttrAccessibleAlwaysThisDeviceOnly`

Defaulting `.always` to `.afterFirstUnlock`, and `.alwaysThisDeviceOnly` to `.afterFirstUnlockThisDeviceOnly`, on iOS 12.0 and above, my initial implementation, didn't feel like the optimal choice. 
It truly felt like the only sensible thing to do was marking `.always` and `.alwaysThisDeviceOnly` as `unavailable` for everyone, while allowing users that genuinely need to rely on those cases to pass them themselves, with the addition of a `.custom` case. 

_I did not include `macCatalyst` in the `#available` statements, as the minimum Swift version for using the library is still set to `4.1`._