### PR TITLE
Improve on `KeychainWrapper`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ KeychainWrapper.standard.remove(forKey: .myKey)
 By default, all items saved to keychain can only be accessed when the device is unlocked. To change this accessibility, an optional `withAccessibility` param can be set on all requests. The enum `KeychainItemAccessibilty` provides an easy way to select the accessibility level desired:
 
 ``` swift
-KeychainWrapper.standard.set("Some String", forKey: "myKey", withAccessibility: .AfterFirstUnlock)
+KeychainWrapper.standard.set("Some String", forKey: "myKey", accessible: .afterFirstUnlock)
 ```
 
 ## Synchronizable Option
@@ -87,15 +87,15 @@ KeychainWrapper.standard.set("Some String", forKey: "myKey", withAccessibility: 
 By default, all items saved to keychain are not synchronizable, so they are not synced with the iCloud. To change this, an  `isSynchronizable` bool param can be set on all requests. You need the item to be synchronized with the iCloud if you want to have it on all of your devices:
  
 ``` swift
-KeychainWrapper.standard.set("Some String", forKey: "myKey", isSynchronizable: true)
+KeychainWrapper.standard.set("Some String", forKey: "myKey", synchronized: true)
 ```
 
 **Important:** You can't modify value for key if it was previously set with different accessibility option. Remove the value for key and set it with new accessibility option. (Otherwise the value will not change).  
 For example:
 ``` swift
-KeychainWrapper.standard.set("String one", forKey: "myKey", withAccessibility: .AfterFirstUnlock)
+KeychainWrapper.standard.set("String one", forKey: "myKey", accessible: .afterFirstUnlock)
 KeychainWrapper.standard.removeObject(forKey: "myKey")
-KeychainWrapper.standard.set("String two", forKey: "myKey", withAccessibility: .Always)
+KeychainWrapper.standard.set("String two", forKey: "myKey", accessible: .afterFirstUnlockThisDeviceOnly)
 ```
 
 ## Installation
@@ -149,7 +149,7 @@ Download and drop ```KeychainWrapper.swift``` and ```KeychainItemAcessibility.sw
 
 ## Release History
 
-* 4.1
+* 4.0.1
 Added conditional logic for CGFloat accessories for when package is used where CGFloat is not available
 
 * 4.0

--- a/SwiftKeychainWrapper.xcodeproj/project.pbxproj
+++ b/SwiftKeychainWrapper.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		9694C2BB1A66097F005B3030 /* SwiftKeychainWrapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9694C2B01A66097F005B3030 /* SwiftKeychainWrapper.framework */; };
 		9694C2CD1A660F90005B3030 /* KeychainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9694C2CC1A660F90005B3030 /* KeychainWrapper.swift */; };
 		9694C2D11A660F9C005B3030 /* TestObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9694C2CF1A660F9C005B3030 /* TestObject.swift */; };
+		E09E48E62523A67A0008AB59 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09E48E52523A67A0008AB59 /* Deprecations.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		9694C2C01A66097F005B3030 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9694C2CC1A660F90005B3030 /* KeychainWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainWrapper.swift; sourceTree = "<group>"; };
 		9694C2CF1A660F9C005B3030 /* TestObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestObject.swift; sourceTree = "<group>"; };
+		E09E48E52523A67A0008AB59 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +139,7 @@
 				5E79BF2E246847600035CAC0 /* KeychainWrapperSubscript.swift */,
 				9694C2CC1A660F90005B3030 /* KeychainWrapper.swift */,
 				1AC6BBD91CCD272C00DE429B /* KeychainItemAccessibility.swift */,
+				E09E48E52523A67A0008AB59 /* Deprecations.swift */,
 				9694C2B21A66097F005B3030 /* Supporting Files */,
 			);
 			path = SwiftKeychainWrapper;
@@ -331,6 +334,7 @@
 			files = (
 				5E79BF2F246847600035CAC0 /* KeychainWrapperSubscript.swift in Sources */,
 				9694C2CD1A660F90005B3030 /* KeychainWrapper.swift in Sources */,
+				E09E48E62523A67A0008AB59 /* Deprecations.swift in Sources */,
 				1AC6BBDA1CCD272C00DE429B /* KeychainItemAccessibility.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftKeychainWrapper/Deprecations.swift
+++ b/SwiftKeychainWrapper/Deprecations.swift
@@ -1,0 +1,283 @@
+//
+//  Deprecations.swift
+//  SwiftKeychainWrapper
+//
+//  Created by Stefano Bertagno on 29/09/20.
+//  Copyright © 2020 Jason Rendel. All rights reserved.
+//
+
+import Foundation
+
+/// An `extension` for deprecated methods.
+public extension KeychainWrapper {
+    /// Check for the existence of a stored object matching `key`.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: `true` if a stored object was found, `false` otherwise.
+    @available(*, deprecated, renamed: "contains(key:accessible:isSynchronizable:)")
+    func hasValue(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+        return contains(key: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+    
+    /// Find the `KeychainItemAccessibility` for a given `key`.
+    ///
+    /// - parameter key: A valid `String`.
+    /// - returns: The related `KeychainItemAccessibility`, if a match was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "accessibility(forKey:)")
+    func accessibilityOfKey(_ key: String) -> KeychainItemAccessibility? {
+        return accessibility(forKey: key)
+    }
+    
+    /// Returns some `Data` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: Some `Data` stored in the keychain if found, `nil` otherwise.
+    @available(*, deprecated, renamed: "data(forKey:accessible:synchronized:)")
+    func data(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Data? {
+        return data(forKey: key, accessible: accessibility, synchronized: false)
+    }
+
+    /// Returns some `Data` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: Some `Data` stored in the keychain if found, `nil` otherwise.
+    @available(*, deprecated, renamed: "data(forKey:accessible:synchronized:)")
+    func data(forKey key: String, isSynchronizable: Bool) -> Data? {
+        return data(forKey: key, accessible: nil, synchronized: isSynchronizable)
+    }
+    
+    /// Returns some `Data` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: Some `Data` stored in the keychain if found, `nil` otherwise.
+    @available(*, deprecated, renamed: "data(forKey:accessible:synchronized:)")
+    func data(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Data? {
+        return data(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+    
+    /// Returns an object matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: An object conforming to `NSCoding` if found, `nil` otherwise.
+    @available(*, deprecated, renamed: "object(forKey:accessible:synchronized:)")
+    func object(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> NSCoding? {
+        return object(forKey: key, accessible: accessibility, synchronized: false) as? NSCoding
+    }
+
+    /// Returns an object matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: An object conforming to `NSCoding` if found, `nil` otherwise.
+    @available(*, deprecated, renamed: "object(forKey:accessible:synchronized:)")
+    func object(forKey key: String, isSynchronizable: Bool) -> NSCoding? {
+        return object(forKey: key, accessible: nil, synchronized: isSynchronizable) as? NSCoding
+    }
+
+    /// Returns an object matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: An object conforming to `NSCoding` if found, `nil` otherwise.
+    @available(*, deprecated, renamed: "object(forKey:accessible:synchronized:)")
+    func object(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> NSCoding? {
+        return object(forKey: key, accessible: accessibility, synchronized: isSynchronizable) as? NSCoding
+    }
+    
+    /// Returns an `Int` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: An `Int` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func integer(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Int? {
+        return integer(forKey: key, accessible: accessibility, synchronized: false)
+    }
+
+    /// Returns an `Int` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: An `Int` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func integer(forKey key: String, isSynchronizable: Bool) -> Int? {
+        return integer(forKey: key, accessible: nil, synchronized: isSynchronizable)
+    }
+    
+    /// Returns an `Int` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: An `Int` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func integer(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Int? {
+        return integer(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+    
+    /// Returns a `Float` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: A `Float` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func float(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Float? {
+        return float(forKey: key, accessible: accessibility, synchronized: false)
+    }
+
+    /// Returns a `Float` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: A `Float` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func float(forKey key: String, isSynchronizable: Bool) -> Float? {
+        return float(forKey: key, accessible: nil, synchronized: isSynchronizable)
+    }
+
+    /// Returns a `Float` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: A `Float` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func float(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Float? {
+        return float(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+    
+    /// Returns a `Double` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: A `Double` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func double(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Double? {
+        return double(forKey: key, accessible: accessibility, synchronized: false)
+    }
+
+    /// Returns a `Double` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: A `Double` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func double(forKey key: String, isSynchronizable: Bool) -> Double? {
+        return double(forKey: key, accessible: nil, synchronized: isSynchronizable)
+    }
+    
+    /// Returns a `Double` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: A `Double` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func double(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Double? {
+        return double(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+    
+    /// Returns a `Bool` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: A `Bool` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func bool(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Bool? {
+        return bool(forKey: key, accessible: accessibility, synchronized: false)
+    }
+
+    /// Returns a `Bool` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: A `Bool` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func bool(forKey key: String, isSynchronizable: Bool) -> Bool? {
+        return bool(forKey: key, accessible: nil, synchronized: isSynchronizable)
+    }
+
+    /// Returns a `Bool` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: A `Bool` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "integer(forKey:accessible:synchronized:)")
+    func bool(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Bool? {
+        return bool(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+    
+    /// Returns a `String` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: A `String` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "string(forKey:accessible:synchronized:)")
+    func string(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> String? {
+        return string(forKey: key, accessible: accessibility, synchronized: false)
+    }
+
+    /// Returns a `String` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: A `String` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "string(forKey:accessible:synchronized:)")
+    func string(forKey key: String, isSynchronizable: Bool) -> String? {
+        return string(forKey: key, accessible: nil, synchronized: isSynchronizable)
+    }
+
+    /// Returns a `String` matching `key`, `accessibility` and synchronization settings.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: A `String` if a stored object was found, `nil` otherwise.
+    @available(*, deprecated, renamed: "string(forKey:accessible:synchronized:)")
+    func string(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> String? {
+        return string(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+    
+    /// Returns a persistent data reference object for a specified key.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: Some persistent `Data` reference if found, `nil` otherwise.
+    @available(*, deprecated, renamed: "reference(forKey:accessible:synchronized:)")
+    func dataRef(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Data? {
+        return reference(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+}

--- a/SwiftKeychainWrapper/Deprecations.swift
+++ b/SwiftKeychainWrapper/Deprecations.swift
@@ -20,7 +20,9 @@ public extension KeychainWrapper {
     ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
     /// - returns: `true` if a stored object was found, `false` otherwise.
     @available(*, deprecated, renamed: "contains(key:accessible:isSynchronizable:)")
-    func hasValue(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    func hasValue(forKey key: String,
+                  withAccessibility accessibility: KeychainItemAccessibility? = nil,
+                  isSynchronizable: Bool = false) -> Bool {
         return contains(key: key, accessible: accessibility, synchronized: isSynchronizable)
     }
     
@@ -292,6 +294,7 @@ public extension KeychainWrapper {
     ///     - key: A valid `String`.
     ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
     /// - returns: `true` if it was successful, `false` otherwise.
+    @available(*, deprecated, renamed: "set(_:forKey:accessible:synchronized:)")
     @discardableResult
     func set<T>(_ value: T,
                 forKey key: String,
@@ -306,6 +309,7 @@ public extension KeychainWrapper {
     ///     - key: A valid `String`.
     ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
     /// - returns: `true` if it was successful, `false` otherwise.
+    @available(*, deprecated, renamed: "set(_:forKey:accessible:synchronized:)")
     @discardableResult
     func set<T>(_ value: T,
                 forKey key: String,
@@ -321,11 +325,96 @@ public extension KeychainWrapper {
     ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
     ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
     /// - returns: `true` if it was successful, `false` otherwise.
+    @available(*, deprecated, renamed: "set(_:forKey:accessible:synchronized:)")
     @discardableResult
     func set<T>(_ value: T,
                 forKey key: String,
                 withAccessibility accessibility: KeychainItemAccessibility?,
                 isSynchronizable: Bool) -> Bool {
         return set(value, forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+    
+    // MARK: Deletion
+    
+    /// Remove an item matching `key` from the keychain.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: `true` if it was successful, `false` otherwise.
+    @available(*, deprecated, renamed: "removeObject(forKey:accessible:synchronized:)")
+    @discardableResult
+    func remove(key: String,
+                withAccessibility accessibility: KeychainItemAccessibility?) -> Bool {
+        return removeObject(forKey: key, accessible: accessibility, synchronized: false)
+    }
+
+    /// Remove an item matching `key` from the keychain.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: `true` if it was successful, `false` otherwise.
+    @available(*, deprecated, renamed: "removeObject(forKey:accessible:synchronized:)")
+    @discardableResult
+    func remove(key: String,
+                isSynchronizable: Bool) -> Bool {
+        return removeObject(forKey: key, accessible: nil, synchronized: isSynchronizable)
+    }
+
+    /// Remove an item matching `key` from the keychain.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: `true` if it was successful, `false` otherwise.
+    @available(*, deprecated, renamed: "removeObject(forKey:accessible:synchronized:)")
+    @discardableResult
+    func remove(key: String,
+                withAccessibility accessibility: KeychainItemAccessibility?,
+                isSynchronizable: Bool) -> Bool {
+        return removeObject(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+        
+    /// Remove an item matching `key` from the keychain.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: `true` if it was successful, `false` otherwise.
+    @available(*, deprecated, renamed: "removeObject(forKey:accessible:synchronized:)")
+    @discardableResult
+    func removeObject(forKey key: String,
+                      withAccessibility accessibility: KeychainItemAccessibility) -> Bool {
+        return removeObject(forKey: key, accessible: accessibility, synchronized: false)
+    }
+
+    /// Remove an item matching `key` from the keychain.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: `true` if it was successful, `false` otherwise.
+    @available(*, deprecated, renamed: "removeObject(forKey:accessible:synchronized:)")
+    @discardableResult
+    func removeObject(forKey key: String,
+                      isSynchronizable: Bool) -> Bool {
+        return removeObject(forKey: key, accessible: nil, synchronized: isSynchronizable)
+    }
+
+    /// Remove an item matching `key` from the keychain.
+    ///
+    /// - parameters:
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: `true` if it was successful, `false` otherwise.
+    @available(*, deprecated, renamed: "removeObject(forKey:accessible:synchronized:)")
+    @discardableResult
+    func removeObject(forKey key: String,
+                      withAccessibility accessibility: KeychainItemAccessibility,
+                      isSynchronizable: Bool) -> Bool {
+        return removeObject(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
 }

--- a/SwiftKeychainWrapper/Deprecations.swift
+++ b/SwiftKeychainWrapper/Deprecations.swift
@@ -10,6 +10,8 @@ import Foundation
 
 /// An `extension` for deprecated methods.
 public extension KeychainWrapper {
+    // MARK: Getters
+    
     /// Check for the existence of a stored object matching `key`.
     ///
     /// - parameters:
@@ -41,7 +43,7 @@ public extension KeychainWrapper {
     func data(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Data? {
         return data(forKey: key, accessible: accessibility, synchronized: false)
     }
-
+    
     /// Returns some `Data` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -75,7 +77,7 @@ public extension KeychainWrapper {
     func object(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> NSCoding? {
         return object(forKey: key, accessible: accessibility, synchronized: false) as? NSCoding
     }
-
+    
     /// Returns an object matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -86,7 +88,7 @@ public extension KeychainWrapper {
     func object(forKey key: String, isSynchronizable: Bool) -> NSCoding? {
         return object(forKey: key, accessible: nil, synchronized: isSynchronizable) as? NSCoding
     }
-
+    
     /// Returns an object matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -109,7 +111,7 @@ public extension KeychainWrapper {
     func integer(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Int? {
         return integer(forKey: key, accessible: accessibility, synchronized: false)
     }
-
+    
     /// Returns an `Int` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -143,7 +145,7 @@ public extension KeychainWrapper {
     func float(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Float? {
         return float(forKey: key, accessible: accessibility, synchronized: false)
     }
-
+    
     /// Returns a `Float` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -154,7 +156,7 @@ public extension KeychainWrapper {
     func float(forKey key: String, isSynchronizable: Bool) -> Float? {
         return float(forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-
+    
     /// Returns a `Float` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -177,7 +179,7 @@ public extension KeychainWrapper {
     func double(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Double? {
         return double(forKey: key, accessible: accessibility, synchronized: false)
     }
-
+    
     /// Returns a `Double` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -211,7 +213,7 @@ public extension KeychainWrapper {
     func bool(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Bool? {
         return bool(forKey: key, accessible: accessibility, synchronized: false)
     }
-
+    
     /// Returns a `Bool` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -222,7 +224,7 @@ public extension KeychainWrapper {
     func bool(forKey key: String, isSynchronizable: Bool) -> Bool? {
         return bool(forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-
+    
     /// Returns a `Bool` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -245,7 +247,7 @@ public extension KeychainWrapper {
     func string(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> String? {
         return string(forKey: key, accessible: accessibility, synchronized: false)
     }
-
+    
     /// Returns a `String` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -256,7 +258,7 @@ public extension KeychainWrapper {
     func string(forKey key: String, isSynchronizable: Bool) -> String? {
         return string(forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-
+    
     /// Returns a `String` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -279,5 +281,51 @@ public extension KeychainWrapper {
     @available(*, deprecated, renamed: "reference(forKey:accessible:synchronized:)")
     func dataRef(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Data? {
         return reference(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
+    }
+    
+    // MARK: Setters
+    
+    /// Store `value` into the keychain.
+    ///
+    /// - parameters:
+    ///     - value: Some value.
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    /// - returns: `true` if it was successful, `false` otherwise.
+    @discardableResult
+    func set<T>(_ value: T,
+                forKey key: String,
+                withAccessibility accessibility: KeychainItemAccessibility?) -> Bool {
+        return set(value, forKey: key, accessible: accessibility, synchronized: false)
+    }
+
+    /// Store `value` into the keychain.
+    ///
+    /// - parameters:
+    ///     - value: Some value.
+    ///     - key: A valid `String`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: `true` if it was successful, `false` otherwise.
+    @discardableResult
+    func set<T>(_ value: T,
+                forKey key: String,
+                isSynchronizable: Bool) -> Bool {
+        return set(value, forKey: key, accessible: nil, synchronized: isSynchronizable)
+    }
+    
+    /// Store `value` into the keychain.
+    ///
+    /// - parameters:
+    ///     - value: Some value.
+    ///     - key: A valid `String`.
+    ///     - accessibility: An optional instance of `KeychainItemAccessibility`. Defaults to `nil`.
+    ///     - isSynchronizable: A valid `Bool`. Defaults to `false`.
+    /// - returns: `true` if it was successful, `false` otherwise.
+    @discardableResult
+    func set<T>(_ value: T,
+                forKey key: String,
+                withAccessibility accessibility: KeychainItemAccessibility?,
+                isSynchronizable: Bool) -> Bool {
+        return set(value, forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
 }

--- a/SwiftKeychainWrapper/Deprecations.swift
+++ b/SwiftKeychainWrapper/Deprecations.swift
@@ -11,7 +11,7 @@ import Foundation
 /// An `extension` for deprecated methods.
 public extension KeychainWrapper {
     // MARK: Getters
-    
+
     /// Check for the existence of a stored object matching `key`.
     ///
     /// - parameters:
@@ -25,7 +25,7 @@ public extension KeychainWrapper {
                   isSynchronizable: Bool = false) -> Bool {
         return contains(key: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-    
+
     /// Find the `KeychainItemAccessibility` for a given `key`.
     ///
     /// - parameter key: A valid `String`.
@@ -34,7 +34,7 @@ public extension KeychainWrapper {
     func accessibilityOfKey(_ key: String) -> KeychainItemAccessibility? {
         return accessibility(forKey: key)
     }
-    
+
     /// Returns some `Data` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -45,7 +45,7 @@ public extension KeychainWrapper {
     func data(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Data? {
         return data(forKey: key, accessible: accessibility, synchronized: false)
     }
-    
+
     /// Returns some `Data` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -56,7 +56,7 @@ public extension KeychainWrapper {
     func data(forKey key: String, isSynchronizable: Bool) -> Data? {
         return data(forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-    
+
     /// Returns some `Data` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -68,7 +68,7 @@ public extension KeychainWrapper {
     func data(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Data? {
         return data(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-    
+
     /// Returns an object matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -79,7 +79,7 @@ public extension KeychainWrapper {
     func object(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> NSCoding? {
         return object(forKey: key, accessible: accessibility, synchronized: false) as? NSCoding
     }
-    
+
     /// Returns an object matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -90,7 +90,7 @@ public extension KeychainWrapper {
     func object(forKey key: String, isSynchronizable: Bool) -> NSCoding? {
         return object(forKey: key, accessible: nil, synchronized: isSynchronizable) as? NSCoding
     }
-    
+
     /// Returns an object matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -102,7 +102,7 @@ public extension KeychainWrapper {
     func object(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> NSCoding? {
         return object(forKey: key, accessible: accessibility, synchronized: isSynchronizable) as? NSCoding
     }
-    
+
     /// Returns an `Int` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -113,7 +113,7 @@ public extension KeychainWrapper {
     func integer(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Int? {
         return integer(forKey: key, accessible: accessibility, synchronized: false)
     }
-    
+
     /// Returns an `Int` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -124,7 +124,7 @@ public extension KeychainWrapper {
     func integer(forKey key: String, isSynchronizable: Bool) -> Int? {
         return integer(forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-    
+
     /// Returns an `Int` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -136,7 +136,7 @@ public extension KeychainWrapper {
     func integer(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Int? {
         return integer(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-    
+
     /// Returns a `Float` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -147,7 +147,7 @@ public extension KeychainWrapper {
     func float(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Float? {
         return float(forKey: key, accessible: accessibility, synchronized: false)
     }
-    
+
     /// Returns a `Float` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -158,7 +158,7 @@ public extension KeychainWrapper {
     func float(forKey key: String, isSynchronizable: Bool) -> Float? {
         return float(forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-    
+
     /// Returns a `Float` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -170,7 +170,7 @@ public extension KeychainWrapper {
     func float(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Float? {
         return float(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-    
+
     /// Returns a `Double` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -181,7 +181,7 @@ public extension KeychainWrapper {
     func double(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Double? {
         return double(forKey: key, accessible: accessibility, synchronized: false)
     }
-    
+
     /// Returns a `Double` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -192,7 +192,7 @@ public extension KeychainWrapper {
     func double(forKey key: String, isSynchronizable: Bool) -> Double? {
         return double(forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-    
+
     /// Returns a `Double` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -204,7 +204,7 @@ public extension KeychainWrapper {
     func double(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Double? {
         return double(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-    
+
     /// Returns a `Bool` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -215,7 +215,7 @@ public extension KeychainWrapper {
     func bool(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> Bool? {
         return bool(forKey: key, accessible: accessibility, synchronized: false)
     }
-    
+
     /// Returns a `Bool` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -226,7 +226,7 @@ public extension KeychainWrapper {
     func bool(forKey key: String, isSynchronizable: Bool) -> Bool? {
         return bool(forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-    
+
     /// Returns a `Bool` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -238,7 +238,7 @@ public extension KeychainWrapper {
     func bool(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> Bool? {
         return bool(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-    
+
     /// Returns a `String` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -249,7 +249,7 @@ public extension KeychainWrapper {
     func string(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?) -> String? {
         return string(forKey: key, accessible: accessibility, synchronized: false)
     }
-    
+
     /// Returns a `String` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -260,7 +260,7 @@ public extension KeychainWrapper {
     func string(forKey key: String, isSynchronizable: Bool) -> String? {
         return string(forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-    
+
     /// Returns a `String` matching `key`, `accessibility` and synchronization settings.
     ///
     /// - parameters:
@@ -272,7 +272,7 @@ public extension KeychainWrapper {
     func string(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility?, isSynchronizable: Bool) -> String? {
         return string(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-    
+
     /// Returns a persistent data reference object for a specified key.
     ///
     /// - parameters:
@@ -284,9 +284,9 @@ public extension KeychainWrapper {
     func dataRef(forKey key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Data? {
         return reference(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-    
+
     // MARK: Setters
-    
+
     /// Store `value` into the keychain.
     ///
     /// - parameters:
@@ -316,7 +316,7 @@ public extension KeychainWrapper {
                 isSynchronizable: Bool) -> Bool {
         return set(value, forKey: key, accessible: nil, synchronized: isSynchronizable)
     }
-    
+
     /// Store `value` into the keychain.
     ///
     /// - parameters:
@@ -333,9 +333,9 @@ public extension KeychainWrapper {
                 isSynchronizable: Bool) -> Bool {
         return set(value, forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-    
+
     // MARK: Deletion
-    
+
     /// Remove an item matching `key` from the keychain.
     ///
     /// - parameters:
@@ -376,7 +376,7 @@ public extension KeychainWrapper {
                 isSynchronizable: Bool) -> Bool {
         return removeObject(forKey: key, accessible: accessibility, synchronized: isSynchronizable)
     }
-        
+
     /// Remove an item matching `key` from the keychain.
     ///
     /// - parameters:

--- a/SwiftKeychainWrapper/KeychainItemAccessibility.swift
+++ b/SwiftKeychainWrapper/KeychainItemAccessibility.swift
@@ -40,7 +40,7 @@ public enum KeychainItemAccessibility {
     */
     @available(iOS 4, *)
     case afterFirstUnlock
-    
+
     /**
      The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
      
@@ -48,7 +48,7 @@ public enum KeychainItemAccessibility {
      */
     @available(iOS 4, *)
     case afterFirstUnlockThisDeviceOnly
-    
+
     /**
      The data in the keychain item can always be accessed regardless of whether the device is locked.
      
@@ -56,7 +56,7 @@ public enum KeychainItemAccessibility {
      */
     @available(iOS 4, *)
     case always
-    
+
     /**
      The data in the keychain can only be accessed when the device is unlocked. Only available if a passcode is set on the device.
      
@@ -64,7 +64,7 @@ public enum KeychainItemAccessibility {
      */
     @available(iOS 8, *)
     case whenPasscodeSetThisDeviceOnly
-    
+
     /**
      The data in the keychain item can always be accessed regardless of whether the device is locked.
      
@@ -72,7 +72,7 @@ public enum KeychainItemAccessibility {
      */
     @available(iOS 4, *)
     case alwaysThisDeviceOnly
-    
+
     /**
      The data in the keychain item can be accessed only while the device is unlocked by the user.
      
@@ -82,7 +82,7 @@ public enum KeychainItemAccessibility {
      */
     @available(iOS 4, *)
     case whenUnlocked
-    
+
     /**
      The data in the keychain item can be accessed only while the device is unlocked by the user.
      
@@ -90,25 +90,25 @@ public enum KeychainItemAccessibility {
      */
     @available(iOS 4, *)
     case whenUnlockedThisDeviceOnly
-    
+
     static func accessibilityForAttributeValue(_ keychainAttrValue: CFString) -> KeychainItemAccessibility? {
         for (key, value) in keychainItemAccessibilityLookup {
             if value == keychainAttrValue {
                 return key
             }
         }
-        
+
         return nil
     }
 }
 
-private let keychainItemAccessibilityLookup: [KeychainItemAccessibility:CFString] = {
-    var lookup: [KeychainItemAccessibility:CFString] = [
+private let keychainItemAccessibilityLookup: [KeychainItemAccessibility: CFString] = {
+    var lookup: [KeychainItemAccessibility: CFString] = [
         .afterFirstUnlock: kSecAttrAccessibleAfterFirstUnlock,
         .afterFirstUnlockThisDeviceOnly: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         .always: kSecAttrAccessibleAlways,
         .whenPasscodeSetThisDeviceOnly: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-        .alwaysThisDeviceOnly : kSecAttrAccessibleAlwaysThisDeviceOnly,
+        .alwaysThisDeviceOnly: kSecAttrAccessibleAlwaysThisDeviceOnly,
         .whenUnlocked: kSecAttrAccessibleWhenUnlocked,
         .whenUnlockedThisDeviceOnly: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
     ]
@@ -116,7 +116,7 @@ private let keychainItemAccessibilityLookup: [KeychainItemAccessibility:CFString
     return lookup
 }()
 
-extension KeychainItemAccessibility : KeychainAttrRepresentable {
+extension KeychainItemAccessibility: KeychainAttrRepresentable {
     internal var keychainAttrValue: CFString {
         return keychainItemAccessibilityLookup[self]!
     }

--- a/SwiftKeychainWrapper/KeychainWrapperSubscript.swift
+++ b/SwiftKeychainWrapper/KeychainWrapperSubscript.swift
@@ -96,7 +96,7 @@ public extension KeychainWrapper {
         }
     }
     #endif
-    
+
     /// Store or retrieve some `Data` in the keychain, matching `key`.
     ///
     /// - parameter key: A valid `Key`.

--- a/SwiftKeychainWrapper/KeychainWrapperSubscript.swift
+++ b/SwiftKeychainWrapper/KeychainWrapperSubscript.swift
@@ -13,15 +13,19 @@ import CoreGraphics
 #endif
 
 public extension KeychainWrapper {
-        
+    /// Remove keychain object mathing `key`.
+    ///
+    /// - parameter key: A valid `Key`.
     func remove(forKey key: Key) {
         removeObject(forKey: key.rawValue)
     }
-    
 }
 
 public extension KeychainWrapper {
-    
+    /// Store or retrieve a `String` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `String`.
     subscript(key: Key) -> String? {
         get { return string(forKey: key) }
         set {
@@ -30,6 +34,10 @@ public extension KeychainWrapper {
         }
     }
 
+    /// Store or retrieve a `Bool` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `Bool`.
     subscript(key: Key) -> Bool? {
         get { return bool(forKey: key) }
         set {
@@ -38,6 +46,10 @@ public extension KeychainWrapper {
         }
     }
 
+    /// Store or retrieve an `Int` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `Int`.
     subscript(key: Key) -> Int? {
         get { return integer(forKey: key) }
         set {
@@ -46,6 +58,10 @@ public extension KeychainWrapper {
         }
     }
 
+    /// Store or retrieve a `Double` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `Double`.
     subscript(key: Key) -> Double? {
         get { return double(forKey: key) }
         set {
@@ -54,6 +70,10 @@ public extension KeychainWrapper {
         }
     }
 
+    /// Store or retrieve a `Float` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `Float`.
     subscript(key: Key) -> Float? {
         get { return float(forKey: key) }
         set {
@@ -63,6 +83,10 @@ public extension KeychainWrapper {
     }
 
     #if canImport(CoreGraphics)
+    /// Store or retrieve a `CGFloat` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `CGFloat`.
     subscript(key: Key) -> CGFloat? {
         get { return cgFloat(forKey: key) }
         set {
@@ -73,6 +97,10 @@ public extension KeychainWrapper {
     }
     #endif
     
+    /// Store or retrieve some `Data` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: Some optional `Data`.
     subscript(key: Key) -> Data? {
         get { return data(forKey: key) }
         set {
@@ -80,85 +108,74 @@ public extension KeychainWrapper {
             set(value, forKey: key.rawValue)
         }
     }
-
 }
 
-
 public extension KeychainWrapper {
-    
-    func data(forKey key: Key) -> Data? {
-        if let value = data(forKey: key.rawValue) {
-            return value
-        }
-        return nil
-    }
+    /// Retrieve some `Data` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: Some optional `Data`.
+    func data(forKey key: Key) -> Data? { return data(forKey: key.rawValue) }
 
-    func bool(forKey key: Key) -> Bool? {
-        if let value = bool(forKey: key.rawValue) {
-            return value
-        }
-        
-        return nil
-    }
+    /// Retrieve a `Bool` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `Bool`.
+    func bool(forKey key: Key) -> Bool? { return bool(forKey: key.rawValue) }
 
-    func integer(forKey key: Key) -> Int? {
-        if let value = integer(forKey: key.rawValue) {
-            return value
-        }
-        
-        return nil
-    }
+    /// Retrieve a `Int` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `Int`.
+    func integer(forKey key: Key) -> Int? { return integer(forKey: key.rawValue) }
 
-    func float(forKey key: Key) -> Float? {
-        if let value = float(forKey: key.rawValue) {
-            return value
-        }
-        
-        return nil
-    }
+    /// Retrieve a `Float` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `Float`.
+    func float(forKey key: Key) -> Float? { return float(forKey: key.rawValue) }
 
     #if canImport(CoreGraphics)
-    func cgFloat(forKey key: Key) -> CGFloat? {
-        if let value = float(forKey: key) {
-            return CGFloat(value)
-        }
-        
-        return nil
-    }
+    /// Retrieve a `CGFloat` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `CGFloat`.
+    func cgFloat(forKey key: Key) -> CGFloat? { return double(forKey: key).flatMap(CGFloat.init) }
     #endif
 
-    func double(forKey key: Key) -> Double? {
-        if let value = double(forKey: key.rawValue) {
-            return value
-        }
-        
-        return nil
-    }
+    /// Retrieve a `Double` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `Double`.
+    func double(forKey key: Key) -> Double? { return double(forKey: key.rawValue) }
 
-    func string(forKey key: Key) -> String? {
-        if let value = string(forKey: key.rawValue) {
-            return value
-        }
-        
-        return nil
-    }
-
+    /// Retrieve a `String` in the keychain, matching `key`.
+    ///
+    /// - parameter key: A valid `Key`.
+    /// - returns: An optional `String`.
+    func string(forKey key: Key) -> String? { return string(forKey: key.rawValue) }
 }
 
-
 public extension KeychainWrapper {
-    
+    /// A `struct` used to persist common keys.
+    ///
+    /// ``` swift
+    /// extension KeychainWrapper.Key {
+    ///     static let myKey: KeychainWrapper.Key = "myKey"
+    /// }
+    /// ```
     struct Key: Hashable, RawRepresentable, ExpressibleByStringLiteral {
+        /// The underlying value.
+        public private(set) var rawValue: String
 
-        public var rawValue: String
+        /// Init.
+        ///
+        /// - parameter rawValue: A valid `String`.
+        public init(rawValue: String) { self.rawValue = rawValue }
 
-        public init(rawValue: String) {
-            self.rawValue = rawValue
-        }
-
-        public init(stringLiteral value: String) {
-            self.rawValue = value
-        }
+        /// Init.
+        /// 
+        /// - parameter value: A valid `String`.
+        public init(stringLiteral value: String) { self.rawValue = value }
     }
-    
 }

--- a/SwiftKeychainWrapperTests/KeychainWrapperDefaultWrapperTests.swift
+++ b/SwiftKeychainWrapperTests/KeychainWrapperDefaultWrapperTests.swift
@@ -45,21 +45,21 @@ class KeychainWrapperDefaultWrapperTests: XCTestCase {
     }
     
     func testHasValueForKey() {
-        XCTAssertFalse(KeychainWrapper.standard.hasValue(forKey: testKey), "Keychain should not have a value for the test key")
+        XCTAssertFalse(KeychainWrapper.standard.contains(key: testKey), "Keychain should not have a value for the test key")
         
         KeychainWrapper.standard.set(testString, forKey: testKey)
         
-        XCTAssertTrue(KeychainWrapper.standard.hasValue(forKey: testKey), "Keychain should have a value for the test key after it is set")
+        XCTAssertTrue(KeychainWrapper.standard.contains(key: testKey), "Keychain should have a value for the test key after it is set")
     }
     
     func testRemoveObjectFromKeychain() {
         KeychainWrapper.standard.set(testString, forKey: testKey)
         
-        XCTAssertTrue(KeychainWrapper.standard.hasValue(forKey: testKey), "Keychain should have a value for the test key after it is set")
+        XCTAssertTrue(KeychainWrapper.standard.contains(key: testKey), "Keychain should have a value for the test key after it is set")
         
         KeychainWrapper.standard.removeObject(forKey: testKey)
         
-        XCTAssertFalse(KeychainWrapper.standard.hasValue(forKey: testKey), "Keychain should not have a value for the test key after it is removed")
+        XCTAssertFalse(KeychainWrapper.standard.contains(key: testKey), "Keychain should not have a value for the test key after it is removed")
     }
     
     func testStringSave() {

--- a/SwiftKeychainWrapperTests/KeychainWrapperDefaultWrapperTests.swift
+++ b/SwiftKeychainWrapperTests/KeychainWrapperDefaultWrapperTests.swift
@@ -184,7 +184,7 @@ class KeychainWrapperDefaultWrapperTests: XCTestCase {
             return
         }
         
-        if KeychainWrapper.standard.dataRef(forKey: testKey) == nil {
+        if KeychainWrapper.standard.reference(forKey: testKey) == nil {
             XCTFail("Data references for Key not found")
         }
         
@@ -199,7 +199,7 @@ class KeychainWrapperDefaultWrapperTests: XCTestCase {
         let retrievedData = KeychainWrapper.standard.data(forKey: testKey)
         XCTAssertNil(retrievedData, "Data for Key should not exist")
         
-        let retrievedDataRef = KeychainWrapper.standard.dataRef(forKey: testKey)
+        let retrievedDataRef = KeychainWrapper.standard.reference(forKey: testKey)
         XCTAssertNil(retrievedDataRef, "Data ref for Key should not exist")
     }
 

--- a/SwiftKeychainWrapperTests/KeychainWrapperTests.swift
+++ b/SwiftKeychainWrapperTests/KeychainWrapperTests.swift
@@ -44,16 +44,14 @@ class KeychainWrapperTests: XCTestCase {
         let key = "testKey"
         
         for accessibilityOption in accessibilityOptions {
-            KeychainWrapper.standard.set("Test123", forKey: key, withAccessibility: accessibilityOption)
-        
-            let accessibilityForKey = KeychainWrapper.standard.accessibilityOfKey(key)
-            
+            KeychainWrapper.standard.set("Test123", forKey: key, accessible: accessibilityOption)
+            let accessibilityForKey = KeychainWrapper.standard.accessibility(forKey: key)
             let accessibilityDescription = String(describing: accessibilityForKey)
             
             XCTAssertEqual(accessibilityForKey, accessibilityOption, "Accessibility does not match. Expected: \(accessibilityOption) Found: \(accessibilityDescription)")
             
             // INFO: If re-using a key but with a different accessibility, first remove the previous key value using removeObjectForKey(:withAccessibility) using the same accessibilty it was saved with 
-            KeychainWrapper.standard.removeObject(forKey: key, withAccessibility: accessibilityOption)
+            KeychainWrapper.standard.removeObject(forKey: key, accessible: accessibilityOption)
         }
     }
 }


### PR DESCRIPTION
Hey @jrendel, great job developing this library 💪 

I'm migrating my libraries and personal code to rely on your **SwiftagramKeychainWrapper**, and other than the deprecation warnings suggestion from #159, I feel like the codebase could use some refining in order to feel more "modern", to bring it in line with newer versions of Swift. 
All changes are additive, **maintaining full backwards compatibility**. 

## Changes

- [x] Add inline documentation for all declarations 

`KeychainItemAccessibility` documentation and updates are left to #159, this only deals with `KeychainWrapper`.

---

- [x] Refactor getters

I agree with your reasoning to both mimic `UserDefaults` methods, and stick with the "phrasing" of arguments and parameters, but I feel like it could be improved on.

```swift
// Something like the code below seems more natural and concise than the previous one.
var data = KeychainWrapper.standard.data(forKey: "key", accessible: .whenUnlocked, synchronized: true)
// And it still retains the previous structure for all common cases.
data = KeychainWrapper.standard.data(forKey: "key")
```

I also considered the following, but it felt half-baked, and ultimately weird.

```swift
let data = KeychainWrapper.standard.data(forKey: "key", accessible: .whenUnlocked, isSynchronizable: true)
```

There's also some boilerplate code (for instance when `guard`-ing or `if`-ing `Optional`s, to just return the value or `nil` afterwards) that can be simplified.

--- 

- [x] Refactor setters (same as above)

You don't actually need specialized methods. One generic function is more than enough 😊 

```swift
@discardableResult
open func set<T>(_ value: T, forKey key: String, /* … */) -> Bool
```
---

- [x] Refactor deletion methods (same as above)
- [x] Refactor private methods

---

- [x] Add throwing functions

Adding throwing functions requires thinking of a "prefix"/"suffix" so they do not create conflicts with their `Bool`-returning counterparts, as I intend to honor backwards compatibility. 
I wanted to go with `fallible`, but I felt like non-proficient English speakers, would find themselves looking for "failable" instead. So I opted for `unsafe`, which still conveys the "throwing" element.

---

- [x] Add `Key` accessibility and synchronization options

`Key` values are always stored using default `KeychainItemAccessibility` and without sync. 
By adding a custom initializer, we can let the user define the behavior they need.  

---

- Consider adding `defaultAccessibility` and `defaultSynchronization`

The library already provides for a `defaultServiceName`, wouldn't it be nice to allow sub`class`es to also override the default `KeychainItemAccessibility` and `isSynchronizable` so they don't need to pass it every single time? If not "out-of-the-box" with `KeychainWrapper`, with something like `ConstrainedKeychainWrapper`, subclassing it. 
An alternative implementation might be instance specific properties, defaulting to `nil`. 

---

Again, please consider this all as just as a suggestion.
Thank you again for your work here.
😊 